### PR TITLE
Update KDE runtime to 6.7 and fixed appstream errors in flathub builder.

### DIFF
--- a/package/dev.levz.TinyImageFinder.metainfo.xml
+++ b/package/dev.levz.TinyImageFinder.metainfo.xml
@@ -20,6 +20,16 @@
     </p>
   </description>
   <releases>
+    <release version="0.1.3" date="2024-07-09">
+        <description>
+        <ul>
+        <li>Update KDE runtime to 6.7.</li>
+        </ul>
+        <ul>
+        <li xml:lang="ru">Обновлена среда исполнения KDE до версии 6.7.</li>
+        </ul>
+        </description>
+    </release>
     <release version="0.1.2" date="2023-08-05">
         <description>
         <ul>
@@ -27,10 +37,10 @@
         <li>Added Dutch translation (credit to Vistaus).</li>
         <li>Update KDE runtime to 6.3.</li>
         </ul>
-        <ul xml:lang="ru">
-        <li>Улучшена работа на устройствах с пальце-ориентированным вводом.</li>
-        <li>Добавлен голландский перевод (спасибо Vistaus).</li>
-        <li>Обновлена среда исполнения KDE до версии 6.3.</li>
+        <ul>
+        <li xml:lang="ru">Улучшена работа на устройствах с пальце-ориентированным вводом.</li>
+        <li xml:lang="ru">Добавлен голландский перевод (спасибо Vistaus).</li>
+        <li xml:lang="ru">Обновлена среда исполнения KDE до версии 6.3.</li>
         </ul>
         </description>
     </release>
@@ -41,10 +51,10 @@
         <li>Image name filters.</li>
         <li>Recursive search - find images in all subfolders.</li>
         </ul>
-        <ul xml:lang="ru">
-        <li>Быстрый поиск и предпросмотр изображений из выбранной папки.</li>
-        <li>Поиск изображений по заданным названиям.</li>
-        <li>Рекурсивный поиск по всем подпапкам.</li>
+        <ul>
+        <li xml:lang="ru">Быстрый поиск и предпросмотр изображений из выбранной папки.</li>
+        <li xml:lang="ru">Поиск изображений по заданным названиям.</li>
+        <li xml:lang="ru">Рекурсивный поиск по всем подпапкам.</li>
         </ul>
         </description>
     </release>


### PR DESCRIPTION
Test build with KDE runtime version 6.7:

flatpak install --user https://dl.flathub.org/build-repo/116714/dev.levz.TinyImageFinder.flatpakref